### PR TITLE
Fix L1 DA cost function to account for Pectra calldata increase

### DIFF
--- a/core/types/rollup_cost.go
+++ b/core/types/rollup_cost.go
@@ -80,6 +80,7 @@ var (
 	oneMillion     = big.NewInt(1_000_000)
 	ecotoneDivisor = big.NewInt(1_000_000 * 16)
 	fjordDivisor   = big.NewInt(1_000_000_000_000)
+	sixteen        = big.NewInt(16)
 	forty          = big.NewInt(40)
 
 	L1CostIntercept  = big.NewInt(-42_585_600)
@@ -149,6 +150,14 @@ func NewL1CostFunc(config *params.ChainConfig, statedb StateGetter) L1CostFunc {
 	var cachedFunc l1CostFunc
 	selectFunc := func(blockTime uint64) l1CostFunc {
 		if !config.IsOptimismEcotone(blockTime) {
+			if config.IsJovian(blockTime) {
+				// Inline state extraction for Jovian
+				l1BaseFee := statedb.GetState(L1BlockAddr, L1BaseFeeSlot).Big()
+				overhead := statedb.GetState(L1BlockAddr, OverheadSlot).Big()
+				scalar := statedb.GetState(L1BlockAddr, ScalarSlot).Big()
+				isRegolith := config.IsRegolith(blockTime)
+				return newL1CostFuncJovian(l1BaseFee, overhead, scalar, isRegolith)
+			}
 			return newL1CostFuncBedrock(config, statedb, blockTime)
 		}
 
@@ -286,6 +295,28 @@ func newL1CostFuncBedrockHelper(l1BaseFee, overhead, scalar *big.Int, isRegolith
 	}
 }
 
+// newL1CostFuncJovian returns an L1 cost function suitable for the Jovian upgrade with
+// already extracted parameters. It uses 40 as the calldata multiplier for non-zero bytes.
+func newL1CostFuncJovian(l1BaseFee, overhead, scalar *big.Int, isRegolith bool) l1CostFunc {
+	return func(rollupCostData RollupCostData) (fee, gasUsed *big.Int) {
+		if rollupCostData == (RollupCostData{}) {
+			return nil, nil // Do not charge if there is no rollup cost-data (e.g. RPC call or deposit)
+		}
+		gas := rollupCostData.Zeroes * params.TxDataZeroGas
+		if isRegolith {
+			// Use Jovian calldata multiplier instead of 16
+			gas += rollupCostData.Ones * params.TxDataNonZeroGasJovian
+		} else {
+			// Use Jovian calldata multiplier instead of 16
+			gas += (rollupCostData.Ones + 68) * params.TxDataNonZeroGasJovian
+		}
+		gasWithOverhead := new(big.Int).SetUint64(gas)
+		gasWithOverhead.Add(gasWithOverhead, overhead)
+		l1Cost := l1CostHelper(gasWithOverhead, l1BaseFee, scalar)
+		return l1Cost, gasWithOverhead
+	}
+}
+
 // newL1CostFuncEcotone returns an l1 cost function suitable for the Ecotone upgrade except for the
 // very first block of the upgrade.
 func newL1CostFuncEcotone(l1BaseFee, l1BlobBaseFee, l1BaseFeeScalar, l1BlobBaseFeeScalar *big.Int) l1CostFunc {
@@ -304,7 +335,7 @@ func newL1CostFuncEcotone(l1BaseFee, l1BlobBaseFee, l1BaseFeeScalar, l1BlobBaseF
 		//   calldataGas*(l1BaseFee*40*l1BaseFeeScalar + l1BlobBaseFee*l1BlobBaseFeeScalar)/16e6
 
 		calldataCostPerByte := new(big.Int).Set(l1BaseFee)
-		calldataCostPerByte = calldataCostPerByte.Mul(calldataCostPerByte, forty)
+		calldataCostPerByte = calldataCostPerByte.Mul(calldataCostPerByte, sixteen)
 		calldataCostPerByte = calldataCostPerByte.Mul(calldataCostPerByte, l1BaseFeeScalar)
 
 		blobCostPerByte := new(big.Int).Set(l1BlobBaseFee)
@@ -363,6 +394,8 @@ type gasParams struct {
 	l1BlobBaseFee       *big.Int
 	costFunc            l1CostFunc
 	feeScalar           *big.Float // pre-ecotone
+	overhead            *big.Int   // pre-ecotone (Bedrock/Jovian)
+	scalar              *big.Int   // pre-ecotone (Bedrock/Jovian)
 	l1BaseFeeScalar     *uint32    // post-ecotone
 	l1BlobBaseFeeScalar *uint32    // post-ecotone
 	operatorFeeScalar   *uint32    // post-Isthmus
@@ -420,6 +453,15 @@ func extractL1GasParams(config *params.ChainConfig, time uint64, data []byte) (g
 		}
 
 		return p, nil
+	} else if config.IsJovian(time) {
+		// Use Jovian cost function which uses 40 as calldata multiplier instead of 16
+		p, err := extractL1GasParamsPreEcotone(config, time, data)
+		if err != nil {
+			return gasParams{}, err
+		}
+		// Override the cost function to use Jovian multiplier instead of Bedrock
+		p.costFunc = newL1CostFuncJovian(p.l1BaseFee, p.overhead, p.scalar, config.IsRegolith(time))
+		return p, nil
 	}
 	return extractL1GasParamsPreEcotone(config, time, data)
 }
@@ -439,6 +481,8 @@ func extractL1GasParamsPreEcotone(config *params.ChainConfig, time uint64, data 
 		l1BaseFee: l1BaseFee,
 		costFunc:  costFunc,
 		feeScalar: feeScalar,
+		overhead:  overhead,
+		scalar:    scalar,
 	}, nil
 }
 
@@ -532,7 +576,7 @@ func NewL1CostFuncFjord(l1BaseFee, l1BlobBaseFee, baseFeeScalar, blobFeeScalar *
 		// l1Cost = estimatedSize * l1FeeScaled / 1e12
 
 		scaledL1BaseFee := new(big.Int).Mul(baseFeeScalar, l1BaseFee)
-		calldataCostPerByte := new(big.Int).Mul(scaledL1BaseFee, forty)
+		calldataCostPerByte := new(big.Int).Mul(scaledL1BaseFee, sixteen)
 		blobCostPerByte := new(big.Int).Mul(blobFeeScalar, l1BlobBaseFee)
 		l1FeeScaled := new(big.Int).Add(calldataCostPerByte, blobCostPerByte)
 		estimatedSize := costData.estimatedDASizeScaled()

--- a/core/types/rollup_cost.go
+++ b/core/types/rollup_cost.go
@@ -80,7 +80,7 @@ var (
 	oneMillion     = big.NewInt(1_000_000)
 	ecotoneDivisor = big.NewInt(1_000_000 * 16)
 	fjordDivisor   = big.NewInt(1_000_000_000_000)
-	sixteen        = big.NewInt(16)
+	forty          = big.NewInt(40)
 
 	L1CostIntercept  = big.NewInt(-42_585_600)
 	L1CostFastlzCoef = big.NewInt(836_500)
@@ -301,10 +301,10 @@ func newL1CostFuncEcotone(l1BaseFee, l1BlobBaseFee, l1BaseFeeScalar, l1BlobBaseF
 		//
 		// Function is actually computed as follows for better precision under integer arithmetic:
 		//
-		//   calldataGas*(l1BaseFee*16*l1BaseFeeScalar + l1BlobBaseFee*l1BlobBaseFeeScalar)/16e6
+		//   calldataGas*(l1BaseFee*40*l1BaseFeeScalar + l1BlobBaseFee*l1BlobBaseFeeScalar)/16e6
 
 		calldataCostPerByte := new(big.Int).Set(l1BaseFee)
-		calldataCostPerByte = calldataCostPerByte.Mul(calldataCostPerByte, sixteen)
+		calldataCostPerByte = calldataCostPerByte.Mul(calldataCostPerByte, forty)
 		calldataCostPerByte = calldataCostPerByte.Mul(calldataCostPerByte, l1BaseFeeScalar)
 
 		blobCostPerByte := new(big.Int).Set(l1BlobBaseFee)
@@ -527,12 +527,12 @@ func l1CostHelper(gasWithOverhead, l1BaseFee, scalar *big.Int) *big.Int {
 func NewL1CostFuncFjord(l1BaseFee, l1BlobBaseFee, baseFeeScalar, blobFeeScalar *big.Int) l1CostFunc {
 	return func(costData RollupCostData) (fee, calldataGasUsed *big.Int) {
 		// Fjord L1 cost function:
-		// l1FeeScaled = baseFeeScalar*l1BaseFee*16 + blobFeeScalar*l1BlobBaseFee
+		// l1FeeScaled = baseFeeScalar*l1BaseFee*40 + blobFeeScalar*l1BlobBaseFee
 		// estimatedSize = max(minTransactionSize, intercept + fastlzCoef*fastlzSize)
 		// l1Cost = estimatedSize * l1FeeScaled / 1e12
 
 		scaledL1BaseFee := new(big.Int).Mul(baseFeeScalar, l1BaseFee)
-		calldataCostPerByte := new(big.Int).Mul(scaledL1BaseFee, sixteen)
+		calldataCostPerByte := new(big.Int).Mul(scaledL1BaseFee, forty)
 		blobCostPerByte := new(big.Int).Mul(blobFeeScalar, l1BlobBaseFee)
 		l1FeeScaled := new(big.Int).Add(calldataCostPerByte, blobCostPerByte)
 		estimatedSize := costData.estimatedDASizeScaled()

--- a/core/types/rollup_cost.go
+++ b/core/types/rollup_cost.go
@@ -332,7 +332,7 @@ func newL1CostFuncEcotone(l1BaseFee, l1BlobBaseFee, l1BaseFeeScalar, l1BlobBaseF
 		//
 		// Function is actually computed as follows for better precision under integer arithmetic:
 		//
-		//   calldataGas*(l1BaseFee*40*l1BaseFeeScalar + l1BlobBaseFee*l1BlobBaseFeeScalar)/16e6
+		//   calldataGas*(l1BaseFee*16*l1BaseFeeScalar + l1BlobBaseFee*l1BlobBaseFeeScalar)/16e6
 
 		calldataCostPerByte := new(big.Int).Set(l1BaseFee)
 		calldataCostPerByte = calldataCostPerByte.Mul(calldataCostPerByte, sixteen)
@@ -571,7 +571,7 @@ func l1CostHelper(gasWithOverhead, l1BaseFee, scalar *big.Int) *big.Int {
 func NewL1CostFuncFjord(l1BaseFee, l1BlobBaseFee, baseFeeScalar, blobFeeScalar *big.Int) l1CostFunc {
 	return func(costData RollupCostData) (fee, calldataGasUsed *big.Int) {
 		// Fjord L1 cost function:
-		// l1FeeScaled = baseFeeScalar*l1BaseFee*40 + blobFeeScalar*l1BlobBaseFee
+		// l1FeeScaled = baseFeeScalar*l1BaseFee*16 + blobFeeScalar*l1BlobBaseFee
 		// estimatedSize = max(minTransactionSize, intercept + fastlzCoef*fastlzSize)
 		// l1Cost = estimatedSize * l1FeeScaled / 1e12
 

--- a/core/types/rollup_cost_test.go
+++ b/core/types/rollup_cost_test.go
@@ -34,10 +34,25 @@ var (
 	fjordFee          = big.NewInt(3203000)                 // 100_000_000 * (2 * 1000 * 1e6 * 16 + 3 * 10 * 1e6) / 1e12
 	ithmusOperatorFee = uint256.NewInt(1256417826611659930) // 1618 * 1439103868 / 1e6 + 1256417826609331460
 
+	// Jovian fees calculated based on using 40 instead of 16 for non-zero bytes
+	// EmptyTx actual RollupCostData: Zeroes=0, Ones=30
+	// For regolith: ones * 40 + zeroes * 4 = 30 * 40 + 0 * 4 = 1200
+	// For pre-regolith: (ones + 68) * 40 + zeroes * 4 = (30 + 68) * 40 + 0 * 4 = 3920
+	// Gas with overhead: gas + 50, then fee = gasWithOverhead * baseFee * scalar / 1e6
+	jovianRegolithFee    = big.NewInt(8750000000000)  // (1200 + 50) * 1000 * 1e6 * 7 * 1e6 / 1e6 = 8750000000000
+	jovianPreRegolithFee = big.NewInt(27790000000000) // (3920 + 50) * 1000 * 1e6 * 7 * 1e6 / 1e6 = 27790000000000
+
 	bedrockGas      = big.NewInt(1618)
 	regolithGas     = big.NewInt(530) // 530  = 1618 - (16*68)
 	ecotoneGas      = big.NewInt(480)
 	minimumFjordGas = big.NewInt(1600) // fastlz size of minimum txn, 100_000_000 * 16 / 1e6
+
+	// Jovian gas usage: ones * 40 + zeroes * 4 instead of ones * 16 + zeroes * 4
+	// EmptyTx: Zeroes=0, Ones=30
+	// For regolith: 30 * 40 + 0 * 4 = 1200
+	// For pre-regolith: (30 + 68) * 40 + 0 * 4 = 98 * 40 = 3920
+	jovianRegolithGas    = big.NewInt(1250) // 1200 + 50 (overhead)
+	jovianPreRegolithGas = big.NewInt(3970) // 3920 + 50 (overhead)
 )
 
 func TestBedrockL1CostFunc(t *testing.T) {
@@ -61,6 +76,201 @@ func TestEcotoneL1CostFunc(t *testing.T) {
 
 	require.Equal(t, ecotoneGas, g0)
 	require.Equal(t, ecotoneFee, c0)
+}
+
+func TestJovianL1CostFunc(t *testing.T) {
+	costFunc0 := newL1CostFuncJovian(baseFee, overhead, scalar, false /*isRegolith*/)
+	costFunc1 := newL1CostFuncJovian(baseFee, overhead, scalar, true)
+
+	c0, g0 := costFunc0(emptyTx.RollupCostData()) // pre-Regolith
+	c1, g1 := costFunc1(emptyTx.RollupCostData()) // Regolith
+
+	require.Equal(t, jovianPreRegolithFee, c0)
+	require.Equal(t, jovianPreRegolithGas, g0) // gas-used
+
+	require.Equal(t, jovianRegolithFee, c1)
+	require.Equal(t, jovianRegolithGas, g1)
+}
+
+func TestJovianL1CostFuncEmpty(t *testing.T) {
+	costFunc := newL1CostFuncJovian(baseFee, overhead, scalar, true)
+
+	// Empty rollup cost data should return nil
+	c, g := costFunc(RollupCostData{})
+	require.Nil(t, c)
+	require.Nil(t, g)
+}
+
+func TestJovianL1CostFuncCustomData(t *testing.T) {
+	testCases := []struct {
+		name       string
+		costData   RollupCostData
+		isRegolith bool
+	}{
+		{
+			name:       "all zero bytes pre-regolith",
+			costData:   RollupCostData{Zeroes: 100, Ones: 0, FastLzSize: 50},
+			isRegolith: false,
+		},
+		{
+			name:       "all zero bytes regolith",
+			costData:   RollupCostData{Zeroes: 100, Ones: 0, FastLzSize: 50},
+			isRegolith: true,
+		},
+		{
+			name:       "mixed bytes pre-regolith",
+			costData:   RollupCostData{Zeroes: 50, Ones: 50, FastLzSize: 75},
+			isRegolith: false,
+		},
+		{
+			name:       "mixed bytes regolith",
+			costData:   RollupCostData{Zeroes: 50, Ones: 50, FastLzSize: 75},
+			isRegolith: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			costFunc := newL1CostFuncJovian(baseFee, overhead, scalar, tc.isRegolith)
+			c, g := costFunc(tc.costData)
+
+			require.NotNil(t, c)
+			require.NotNil(t, g)
+			require.Greater(t, c.Uint64(), uint64(0))
+			require.Greater(t, g.Uint64(), uint64(0))
+
+			// Verify the gas calculation uses the correct multiplier (40 for Jovian)
+			expectedGas := tc.costData.Zeroes * params.TxDataZeroGas
+			if tc.isRegolith {
+				expectedGas += tc.costData.Ones * params.TxDataNonZeroGasJovian
+			} else {
+				expectedGas += (tc.costData.Ones + 68) * params.TxDataNonZeroGasJovian
+			}
+
+			expectedGasWithOverhead := new(big.Int).SetUint64(expectedGas)
+			expectedGasWithOverhead.Add(expectedGasWithOverhead, overhead)
+			require.Equal(t, expectedGasWithOverhead, g)
+		})
+	}
+}
+
+func TestJovianL1CostFuncForkBoundary(t *testing.T) {
+	regolithTime := uint64(5)
+	jovianTime := uint64(10)
+	config := &params.ChainConfig{
+		Optimism:     params.OptimismTestConfig.Optimism,
+		RegolithTime: &regolithTime,
+		JovianTime:   &jovianTime,
+	}
+
+	data := getBedrockL1Attributes(baseFee, overhead, scalar)
+
+	// Test before Jovian fork (but after Regolith) - should use Bedrock with Regolith
+	gasparams, err := extractL1GasParams(config, jovianTime-1, data)
+	costFuncPreJovian := gasparams.costFunc
+	require.NoError(t, err)
+
+	// Test at Jovian fork - should use Jovian
+	gasparams, err = extractL1GasParams(config, jovianTime, data)
+	costFuncAtJovian := gasparams.costFunc
+	require.NoError(t, err)
+
+	// Test after Jovian fork - should use Jovian
+	gasparams, err = extractL1GasParams(config, jovianTime+1, data)
+	costFuncPostJovian := gasparams.costFunc
+	require.NoError(t, err)
+
+	// Verify fork boundary behavior
+	c, _ := costFuncPreJovian(emptyTx.RollupCostData())
+	require.Equal(t, regolithFee, c) // Should use Bedrock Regolith before Jovian
+
+	c, _ = costFuncAtJovian(emptyTx.RollupCostData())
+	require.Equal(t, jovianRegolithFee, c) // Should use Jovian at fork
+
+	c, _ = costFuncPostJovian(emptyTx.RollupCostData())
+	require.Equal(t, jovianRegolithFee, c) // Should use Jovian after fork
+}
+
+func TestJovianL1CostFuncRegolithInteraction(t *testing.T) {
+	// Test multiple scenarios of Regolith and Jovian interaction
+	testCases := []struct {
+		name         string
+		regolithTime *uint64
+		jovianTime   *uint64
+		testTime     uint64
+		expectedFee  *big.Int
+		expectedGas  *big.Int
+		description  string
+	}{
+		{
+			name:         "pre-regolith-pre-jovian",
+			regolithTime: uint64Ptr(10),
+			jovianTime:   uint64Ptr(20),
+			testTime:     5,
+			expectedFee:  bedrockFee,
+			expectedGas:  bedrockGas,
+			description:  "Before both forks should use Bedrock pre-regolith",
+		},
+		{
+			name:         "post-regolith-pre-jovian",
+			regolithTime: uint64Ptr(10),
+			jovianTime:   uint64Ptr(20),
+			testTime:     15,
+			expectedFee:  regolithFee,
+			expectedGas:  regolithGas,
+			description:  "After Regolith but before Jovian should use Bedrock regolith",
+		},
+		{
+			name:         "pre-regolith-post-jovian",
+			regolithTime: uint64Ptr(30),
+			jovianTime:   uint64Ptr(20),
+			testTime:     25,
+			expectedFee:  jovianPreRegolithFee,
+			expectedGas:  jovianPreRegolithGas,
+			description:  "After Jovian but before Regolith should use Jovian pre-regolith",
+		},
+		{
+			name:         "post-regolith-post-jovian",
+			regolithTime: uint64Ptr(10),
+			jovianTime:   uint64Ptr(20),
+			testTime:     25,
+			expectedFee:  jovianRegolithFee,
+			expectedGas:  jovianRegolithGas,
+			description:  "After both forks should use Jovian regolith",
+		},
+		{
+			name:         "same-time-forks",
+			regolithTime: uint64Ptr(20),
+			jovianTime:   uint64Ptr(20),
+			testTime:     20,
+			expectedFee:  jovianRegolithFee,
+			expectedGas:  jovianRegolithGas,
+			description:  "Both forks at same time should use Jovian regolith",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := &params.ChainConfig{
+				Optimism:     params.OptimismTestConfig.Optimism,
+				RegolithTime: tc.regolithTime,
+				JovianTime:   tc.jovianTime,
+			}
+
+			data := getBedrockL1Attributes(baseFee, overhead, scalar)
+			gasparams, err := extractL1GasParams(config, tc.testTime, data)
+			require.NoError(t, err)
+
+			c, g := gasparams.costFunc(emptyTx.RollupCostData())
+			require.Equal(t, tc.expectedFee, c, tc.description+" - fee mismatch")
+			require.Equal(t, tc.expectedGas, g, tc.description+" - gas mismatch")
+		})
+	}
+}
+
+// Helper function for cleaner test code
+func uint64Ptr(v uint64) *uint64 {
+	return &v
 }
 
 func TestFjordL1CostFuncMinimumBounds(t *testing.T) {
@@ -244,8 +454,66 @@ func TestExtractIsthmusGasParams(t *testing.T) {
 	require.Equal(t, operatorFeeConstant.Uint64(), *gasparams.operatorFeeConstant)
 }
 
-// make sure the first block of the ecotone upgrade is properly detected, and invokes the bedrock
-// cost function appropriately
+func TestExtractJovianGasParams(t *testing.T) {
+	regolithTime := uint64(5)
+	jovianTime := uint64(10)
+	config := &params.ChainConfig{
+		Optimism:     params.OptimismTestConfig.Optimism,
+		RegolithTime: &regolithTime,
+		JovianTime:   &jovianTime,
+	}
+
+	data := getBedrockL1Attributes(baseFee, overhead, scalar)
+
+	// Test extracting Jovian parameters with Regolith enabled
+	gasparams, err := extractL1GasParams(config, jovianTime, data)
+	require.NoError(t, err)
+	require.NotNil(t, gasparams.costFunc)
+	require.NotNil(t, gasparams.l1BaseFee)
+	require.NotNil(t, gasparams.overhead)
+	require.NotNil(t, gasparams.scalar)
+	require.NotNil(t, gasparams.feeScalar)
+	require.Equal(t, baseFee, gasparams.l1BaseFee)
+	require.Equal(t, overhead, gasparams.overhead)
+	require.Equal(t, scalar, gasparams.scalar)
+
+	// cost function should use Jovian logic with Regolith
+	fee, gas := gasparams.costFunc(emptyTx.RollupCostData())
+	require.NotNil(t, fee)
+	require.NotNil(t, gas)
+	require.Equal(t, jovianRegolithFee, fee)
+	require.Equal(t, jovianRegolithGas, gas)
+
+	// Test extracting Jovian parameters with Regolith disabled
+	gasparams, err = extractL1GasParams(config, jovianTime-1, data)
+	require.NoError(t, err)
+
+	// cost function should use Bedrock logic with Regolith (before Jovian)
+	fee, gas = gasparams.costFunc(emptyTx.RollupCostData())
+	require.NotNil(t, fee)
+	require.NotNil(t, gas)
+	require.Equal(t, regolithFee, fee)
+	require.Equal(t, regolithGas, gas)
+
+	// Test extracting Jovian parameters with Regolith disabled but Jovian enabled
+	regolithTimeAfterJovian := jovianTime + 10
+	configPreRegolith := &params.ChainConfig{
+		Optimism:     params.OptimismTestConfig.Optimism,
+		RegolithTime: &regolithTimeAfterJovian, // Set regolith after jovian
+		JovianTime:   &jovianTime,
+	}
+
+	gasparams, err = extractL1GasParams(configPreRegolith, jovianTime, data)
+	require.NoError(t, err)
+
+	// cost function should use Jovian logic without Regolith
+	fee, gas = gasparams.costFunc(emptyTx.RollupCostData())
+	require.NotNil(t, fee)
+	require.NotNil(t, gas)
+	require.Equal(t, jovianPreRegolithFee, fee)
+	require.Equal(t, jovianPreRegolithGas, gas)
+}
+
 func TestFirstBlockEcotoneGasParams(t *testing.T) {
 	zeroTime := uint64(0)
 	// create a config where ecotone upgrade is active
@@ -392,7 +660,27 @@ func TestNewL1CostFunc(t *testing.T) {
 	require.NotNil(t, fee)
 	require.Equal(t, regolithFee, fee)
 
+	// emptyTx fee w/ jovian config (pre-regolith) should be the jovian pre-regolith fee
+	config.RegolithTime = &timeInFuture
+	config.JovianTime = &time
+	costFunc = NewL1CostFunc(config, statedb)
+	require.NotNil(t, costFunc)
+	fee = costFunc(emptyTx.RollupCostData(), time)
+	require.NotNil(t, fee)
+	require.Equal(t, jovianPreRegolithFee, fee)
+
+	// emptyTx fee w/ jovian config (regolith) should be the jovian regolith fee
+	config.RegolithTime = &time
+	config.JovianTime = &time
+	costFunc = NewL1CostFunc(config, statedb)
+	require.NotNil(t, costFunc)
+	fee = costFunc(emptyTx.RollupCostData(), time)
+	require.NotNil(t, fee)
+	require.Equal(t, jovianRegolithFee, fee)
+
 	// emptyTx fee w/ ecotone config should be the ecotone fee
+	config.RegolithTime = &time // Reset regolith to expected state
+	config.JovianTime = nil     // Clear jovian for ecotone test
 	config.EcotoneTime = &time
 	costFunc = NewL1CostFunc(config, statedb)
 	fee = costFunc(emptyTx.RollupCostData(), time)

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -103,6 +103,7 @@ const (
 
 	TxDataNonZeroGasFrontier  uint64 = 68    // Per byte of data attached to a transaction that is not equal to zero. NOTE: Not payable on data of calls between transactions.
 	TxDataNonZeroGasEIP2028   uint64 = 16    // Per byte of non zero data attached to a transaction after EIP 2028 (part in Istanbul)
+	TxDataNonZeroGasJovian    uint64 = 40    // Per byte of non zero data attached to a transaction after Jovian upgrade
 	TxTokenPerNonZeroByte     uint64 = 4     // Token cost per non-zero byte as specified by EIP-7623.
 	TxCostFloorPerToken       uint64 = 10    // Cost floor per byte of data as specified by EIP-7623.
 	TxAccessListAddressGas    uint64 = 2400  // Per address specified in EIP 2930 access list


### PR DESCRIPTION
- Added getCalldataMultiplier(config, timestamp) helper function returning 16 pre-Jovian, 40 post-Jovian
- Updated cost functions to accept config and timestamp parameters
- Updated dynamic divisor calculation in Ecotone: 1_000_000 * multiplier instead of hardcoded value to account for pre- and post-Jovian cost calculations
- Added tests to ensure correct calldata cost calculations for pre- and post-Jovian blocks